### PR TITLE
Open Options menu on install

### DIFF
--- a/background/script.js
+++ b/background/script.js
@@ -25,6 +25,10 @@ chrome.storage.sync.get({
 // If so, show the user the changelog
 // var thisVersion = chrome.runtime.getManifest().version;
 chrome.runtime.onInstalled.addListener(function(details) {
+  if (details.reason == "install" || details.reason == "update") {
+    // Open a new tab to show changelog html page
+    chrome.tabs.create({ url: "../options/options.html" });
+  }
 });
 // Keep the extensions service worker alive
 keepServiceRunning();

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "homepage_url": "https://github.com/stevenvenner/samltoawsstskeys",
   "name": "SAML to AWS STS Keys Conversion",
   "description": "Generates file with AWS STS Keys after logging in to AWS webconsole using SSO (SAML 2.0). It leverages 'assumeRoleWithSAML' API.",
-  "version": "3.4",
+  "version": "3.6",
   "icons": {  "16": "icons/icon_16.png",
               "32": "icons/icon_32.png",
               "64": "icons/icon_64.png",

--- a/options/options.html
+++ b/options/options.html
@@ -56,6 +56,7 @@
     <div id="divSave">
       <div id="status" class="inline-div"></div>
       <button id="save">Save</button>
+      <label><-- click Save to activate! Then go log into your AWS SAML Provider.</label><br>
     </div>
   </div>
   <script src="options.js"></script>


### PR DESCRIPTION
User needs to SAVE settings before the extension works. This opens the options menu with a label for the save button.